### PR TITLE
replace sklearn dependency with scikit-learn

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     napari
     magic-class
     scipy
-    sklearn
+    scikit-learn
     scikit-image
     matplotlib
     joblib


### PR DESCRIPTION
Hi @SanderSMFISH ,

just another suggestion: When installing napari-buds, `sklearn` in version 0.0 is installed. This is unusual and I presume, the requirement `scikit-learn` should be installed instead.

See also:
https://pypi.org/project/sklearn/

Best,
Robert
